### PR TITLE
OpenAPI 3.0 securityschemes fix for oauth2

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -283,7 +283,7 @@ const getHeadersArray = function (openApi, path, method) {
       const authType = secDefinition.type.toLowerCase();
       let authScheme = null;
       
-      if(authType !== 'apikey'){
+      if(authType !== 'apikey' && authType !== 'oauth2'){
         authScheme = secDefinition.scheme.toLowerCase();
       }
       


### PR DESCRIPTION
Fix securitySchemes validations in OpenAPI 3.0 for type oauth2
Ref: https://swagger.io/docs/specification/authentication/oauth2/